### PR TITLE
Remove automatic sleep when rate limit is hit

### DIFF
--- a/lib/godfist/http.ex
+++ b/lib/godfist/http.ex
@@ -55,7 +55,7 @@ defmodule Godfist.HTTP do
       {:ok, %{status_code: 415}} ->
         {:error, "Unsupported media type. Check the Content-Type header."}
       {:ok, %{status_code: 429}} ->
-        {:error, "Rate eimit exceeded."}
+        {:error, "Rate limit exceeded."}
       {:error, reason} ->
         {:error, reason}
     end

--- a/lib/godfist/http.ex
+++ b/lib/godfist/http.ex
@@ -40,8 +40,6 @@ defmodule Godfist.HTTP do
     end
   end
   defp parse({:error, _}, _, _) do
-    Process.sleep(5000)
-
     {:error, "Rate limit hit, let's slow down"}
   end
 
@@ -57,7 +55,7 @@ defmodule Godfist.HTTP do
       {:ok, %{status_code: 415}} ->
         {:error, "Unsupported media type. Check the Content-Type header."}
       {:ok, %{status_code: 429}} ->
-        {:error, "Rate limit exceeded."}
+        {:error, "Rate eimit exceeded."}
       {:error, reason} ->
         {:error, reason}
     end


### PR DESCRIPTION
I think either it should be up to the client to decide what to do when a rate-limit is hit, or the built-in behavior should be smarter (e.g. make an inspect_bucket call to get the amount of MS before the bucket resets and wait that much time, then automatically retry or something similar). 