### PR TITLE
Supports rate limits per method and for dev-keys.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: elixir
+elixir:
+  - 1.5.1
+otp_release:
+  - 20.0
+branches:
+  only:
+    - smarter-rate-limits

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ otp_release:
 branches:
   only:
     - smarter-rate-limits
+    - master

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First include `godfist` in your `mix.exs` and add it to your applications.
 ```elixir
 [extra_applications: :godfist, ...]
 ...
-{:godfist, "~> 0.2.2"}
+{:godfist, "~> 0.3.0"}
 ```
 
 You can use `{:godfist, github: "aguxez/godfist"}` for the development version.
@@ -25,12 +25,18 @@ Remember to set your api key on your `config.exs` with the next params.
 
 ```elixir
 config :godfist,
-token: "YOUR API KEY",
-time: 1000, # This is the minimum default from Riot, set this time in miliseconds.
-amount: 20 # Amount of request limit, default minimum is 20 each second for development.
+  token: "YOUR API KEY"
 ```
 
-Or export the api key as "RIOT_TOKEN": `export RIOT_TOKEN="token"`
+Or export the api key as "RIOT_TOKEN": `export RIOT_TOKEN="token"` and start making calls.
+
+## Changes
+### 0.3.0
+1. Deprecated `Godfist.League.get_entry/2` for `Godfist.League.positions/2`.
+2. Rate limit options are not given to `config.exs` anymore, just `:token`.
+3. Implemented a different way of handling rate limits, soon to be overridable for your own solution.
 
 
-#### TODO: Add tournament endpoints.
+### TODO
+- [ ] Add tournament endpoints.
+- [ ] Let users implement their own rate limit solutions instead of the built-in.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Godfist
+# Godfist [![Build Status](https://travis-ci.org/aguxez/godfist.svg?branch=rate-limits-back)](https://travis-ci.org/aguxez/godfist)
 
 ## Godfist is a wrapper for League of Legends' ReST API written in Elixir.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,10 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+if Mix.env() == :prod do
+  config :godfist, rates: :prod
+else
+  config :godfist, rates: :dev
+end
+
 import_config "#{Mix.env}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,4 +8,4 @@ else
   config :godfist, rates: :dev
 end
 
-import_config "#{Mix.env}.exs"
+# import_config "#{Mix.env}.exs"

--- a/lib/godfist.ex
+++ b/lib/godfist.ex
@@ -145,9 +145,8 @@ defmodule Godfist do
   iex> Godfist.champion_by_name(["Lee Sin", "Rek'Sai", "Nocturne"])
   ```
   """
-  def champion_by_name(champions, locale \\ :us)
-
   @spec champion_by_name(list, atom) :: list | MatchError
+  def champion_by_name(champions, locale \\ :us)
   def champion_by_name(champions, locale) when is_list(champions) do
     champions
     |> Stream.map(fn champs -> champion_by_name(champs, locale) end)
@@ -210,9 +209,9 @@ defmodule Godfist do
     end
   end
 
-  # Map trough the champ list and filter the ones that are similar to the name given.
-  defp find_champs(champ_list, name), do:
-    champ_list
-    |> Enum.filter(fn{_k, v} -> String.contains?(v["name"], name) end)
-    |> Enum.map(&(&1))
+  # Map trough the champ list and filter the ones that are similar to the given
+  # name.
+  defp find_champs(champ_list, name) do
+    Enum.filter(champ_list, fn{_k, v} -> String.contains?(v["name"], name) end)
+  end
 end

--- a/lib/godfist.ex
+++ b/lib/godfist.ex
@@ -13,9 +13,7 @@ defmodule Godfist do
 
   ```elixir
   config :godfist,
-  token: "YOUR API KEY",
-  time: 1000, # This is the minimum default from Riot, set this time in miliseconds.
-  amount: 10 # Amount of request limit, default minium is 10 each 10 seconds.
+    token: "YOUR API KEY"
   ```
   """
 
@@ -209,7 +207,7 @@ defmodule Godfist do
     end
   end
 
-  # Map trough the champ list and filter the ones that are similar to the given
+  # Map through the champ list and filter the ones that are similar to the given
   # name.
   defp find_champs(champ_list, name) do
     Enum.filter(champ_list, fn{_k, v} -> String.contains?(v["name"], name) end)

--- a/lib/godfist/application.ex
+++ b/lib/godfist/application.ex
@@ -1,6 +1,8 @@
 defmodule Godfist.Application do
   @moduledoc false
 
+  alias Godfist.LeagueRates
+
   def start(_type, _args) do
     import Supervisor.Spec
 
@@ -8,7 +10,8 @@ defmodule Godfist.Application do
       worker(Cachex, [:id_cache, [default_ttl: 86_400_000], []], id: 1),
       worker(Cachex, [:summid_cache, [default_ttl: 86_400_000], []], id: 2),
       worker(Cachex, [:champion, [default_ttl: 86_400_000], []], id: 3),
-      worker(Cachex, [:all_champs, [default_ttl: 14_400_000], []], id: 4)
+      worker(Cachex, [:all_champs, [default_ttl: 14_400_000], []], id: 4),
+      worker(LeagueRates, []),
     ]
 
     Supervisor.start_link(children, strategy: :one_for_all)

--- a/lib/godfist/http.ex
+++ b/lib/godfist/http.ex
@@ -38,7 +38,7 @@ defmodule Godfist.HTTP do
         opt_time = Keyword.get(opt, :time)
         opt_amount = Keyword.get(opt, :amount)
 
-        region
+        "#{region}_endpoint"
         |> ExRated.check_rate(opt_time, opt_amount)
         |> parse(url, rest)
       _ ->
@@ -49,11 +49,12 @@ defmodule Godfist.HTTP do
   # Returns tuple to check limits on ExRated for dev keys.
   defp check_exrated_limits(region) do
     {
-      ExRated.check_rate("#{region}-1", 1000, 20),
-      ExRated.check_rate("#{region}-2", 120_000, 100)
+      ExRated.check_rate("#{region}_short", 1000, 20),
+      ExRated.check_rate("#{region}_long", 120_000, 100)
     }
   end
 
+  # this function is for :prod rates
   defp parse({:ok, _}, url, rest), do: parse(url, rest)
   defp parse({:error, _}, _, _), do: {:error, "Rate limit hit"}
   defp parse(url, rest) do

--- a/lib/godfist/http.ex
+++ b/lib/godfist/http.ex
@@ -49,8 +49,8 @@ defmodule Godfist.HTTP do
   # Returns tuple to check limits on ExRated for dev keys.
   defp check_exrated_limits(region) do
     {
-      ExRated.check_rate("#{region}-1", 20, 1000),
-      ExRated.check_rate("#{region}-2", 100, 120_000)
+      ExRated.check_rate("#{region}-1", 1000, 20),
+      ExRated.check_rate("#{region}-2", 120_000, 100)
     }
   end
 

--- a/lib/godfist/league_rates.ex
+++ b/lib/godfist/league_rates.ex
@@ -48,13 +48,13 @@ defmodule Godfist.LeagueRates do
   # the other endpoints (Matches, Runes, etc...)
   def handle_call({:handle_rate, region, rest, endpoint}, _from, state)
   when is_nil(endpoint) do
-    {time, amount} = Keyword.get(@rates, region)
+    {amount, time} = Keyword.get(@rates, region)
 
     {:reply, HTTP.get(region, rest, time: time, amount: amount), state}
   end
 
   def handle_call({:handle_rate, region, rest, endpoint}, _from, state) do
-    {time, amount} = Keyword.get(@rates, endpoint)
+    {amount, time} = Keyword.get(@rates, endpoint)
 
     {:reply, HTTP.get(region, rest, time: time, amount: amount), state}
   end

--- a/lib/godfist/league_rates.ex
+++ b/lib/godfist/league_rates.ex
@@ -35,7 +35,8 @@ defmodule Godfist.LeagueRates do
     do: GenServer.start_link(__MODULE__, %{}, name: :league_limit)
 
   def handle_rate(region, rest, endpoint \\ nil) do
-    GenServer.call(:league_limit, {:handle_rate, region, rest, endpoint}, 7000)
+    GenServer.call(:league_limit, {:handle_rate, region, rest, endpoint},
+                   :infinity)
   end
 
   # Server

--- a/lib/godfist/league_rates.ex
+++ b/lib/godfist/league_rates.ex
@@ -1,0 +1,60 @@
+defmodule Godfist.LeagueRates do
+  @moduledoc false
+
+  # Handles checking the information passed and assigning the correct
+  # limit to the request.
+
+  use GenServer
+
+  alias Godfist.HTTP
+
+  # Rates for different servers.
+  @rates [
+    # "League" endpoints/servers
+    euw: {300, 60_000},
+    na: {270, 60_000},
+    eune: {135, 60_000},
+    br: {90, 60_000},
+    kr: {90, 60_000},
+    lan: {80, 60_000},
+    las: {80, 60_000},
+    tr: {60, 60_000},
+    oce: {55, 60_000},
+    jp: {35, 60_000},
+    ru: {35, 60_000},
+    # other endpoints
+    match: {500, 10_000},
+    matchlist: {1000, 10_000},
+    champion_masteries_runes: {400, 60_000},
+    static: {10, 3_600_000},
+    other: {20_000, 10_000}
+  ]
+
+  # API
+  def start_link,
+    do: GenServer.start_link(__MODULE__, %{}, name: :league_limit)
+
+  def handle_rate(region, rest, endpoint \\ nil) do
+    GenServer.call(:league_limit, {:handle_rate, region, rest, endpoint}, 7000)
+  end
+
+  # Server
+  def init(state),
+    do: {:ok, state}
+
+  # This first handler is matching on the "Leagues" endpoints,
+  # that's why endpoint is nil, that arg is meant to be used with
+  # the other endpoints (Matches, Runes, etc...)
+  def handle_call({:handle_rate, region, rest, endpoint}, _from, state)
+  when is_nil(endpoint) do
+    {time, amount} = Keyword.get(@rates, region)
+
+    {:reply, HTTP.get(region, rest, time: time, amount: amount), state}
+  end
+
+  def handle_call({:handle_rate, region, rest, endpoint}, _from, state) do
+    {time, amount} = Keyword.get(@rates, endpoint)
+
+    {:reply, HTTP.get(region, rest, time: time, amount: amount), state}
+  end
+end

--- a/lib/godfist/requests/champion.ex
+++ b/lib/godfist/requests/champion.ex
@@ -3,7 +3,7 @@ defmodule Godfist.Champion do
   Module to interact with the Champions endpoint
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @endpoint "/lol/platform/v3/champions/"
 
@@ -24,7 +24,7 @@ defmodule Godfist.Champion do
     free_to_play = Keyword.get(opts, :ftp, false)
     rest = @endpoint <> "?freeToPlay=#{free_to_play}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :champion_masteries_runes)
   end
 
   @doc """
@@ -39,6 +39,6 @@ defmodule Godfist.Champion do
   def by_id(region, id) do
     rest = @endpoint <> "#{id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :champion_masteries_runes)
   end
 end

--- a/lib/godfist/requests/champion_mastery.ex
+++ b/lib/godfist/requests/champion_mastery.ex
@@ -3,7 +3,7 @@ defmodule Godfist.ChampionMastery do
   Module to get Champion masteries
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @endpoint "/lol/champion-mastery/v3"
 
@@ -20,7 +20,7 @@ defmodule Godfist.ChampionMastery do
   def by_summoner(region, id) do
     rest = @endpoint <> "/champion-masteries/by-summoner/#{id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 
   @doc """
@@ -36,7 +36,7 @@ defmodule Godfist.ChampionMastery do
   def by_champion(region, id, champ_id) do
     rest = @endpoint <> "/champion-masteries/by-summoner/#{id}/by-champion/#{champ_id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 
   @doc """
@@ -52,6 +52,6 @@ defmodule Godfist.ChampionMastery do
   def total(region, id) do
     rest = @endpoint <> "/scores/by-summoner/#{id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 end

--- a/lib/godfist/requests/datadragon/data.ex
+++ b/lib/godfist/requests/datadragon/data.ex
@@ -16,7 +16,7 @@ defmodule Godfist.DataDragon.Data do
   variations regarding languages on each country.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @dragon :dragon
   @endpoint "/7.11.1/data"
@@ -66,7 +66,7 @@ defmodule Godfist.DataDragon.Data do
     lang = get_loc(locale)
     rest = @endpoint <> "/#{lang}/profileicon.json"
 
-    HTTP.get(region: @dragon, rest: rest)
+    LeagueRates.handle_rate(@dragon, rest, :other)
   end
 
   @doc """
@@ -83,7 +83,7 @@ defmodule Godfist.DataDragon.Data do
     lang = get_loc(locale)
     rest = @endpoint <> "/#{lang}/champion.json"
 
-    HTTP.get(region: @dragon, rest: rest)
+    LeagueRates.handle_rate(@dragon, rest, :other)
   end
 
   @doc """
@@ -100,7 +100,7 @@ defmodule Godfist.DataDragon.Data do
     lang = get_loc(locale)
     rest = @endpoint <> "/#{lang}/champion/#{name}.json"
 
-    HTTP.get(region: @dragon, rest: rest)
+    LeagueRates.handle_rate(@dragon, rest, :other)
   end
 
   @doc """
@@ -117,7 +117,7 @@ defmodule Godfist.DataDragon.Data do
     lang = get_loc(locale)
     rest = @endpoint <> "/#{lang}/item.json"
 
-    HTTP.get(region: @dragon, rest: rest)
+    LeagueRates.handle_rate(@dragon, rest, :other)
   end
 
   @doc """
@@ -134,7 +134,7 @@ defmodule Godfist.DataDragon.Data do
     lang = get_loc(locale)
     rest = @endpoint <> "/#{lang}/mastery.json"
 
-    HTTP.get(region: @dragon, rest: rest)
+    LeagueRates.handle_rate(@dragon, rest, :other)
   end
 
   @doc """
@@ -151,7 +151,7 @@ defmodule Godfist.DataDragon.Data do
     lang = get_loc(locale)
     rest = @endpoint <> "/#{lang}/rune.json"
 
-    HTTP.get(region: @dragon, rest: rest)
+    LeagueRates.handle_rate(@dragon, rest, :other)
   end
 
   @doc """
@@ -168,9 +168,8 @@ defmodule Godfist.DataDragon.Data do
     lang = get_loc(locale)
     rest = @endpoint <> "/#{lang}/summoner.json"
 
-    HTTP.get(region: @dragon, rest: rest)
+    LeagueRates.handle_rate(@dragon, rest, :other)
   end
-
 
   # priv to get locale
   defp get_loc(locale), do: Map.get(@languages, locale)

--- a/lib/godfist/requests/league.ex
+++ b/lib/godfist/requests/league.ex
@@ -3,78 +3,60 @@ defmodule Godfist.League do
   Module to interact with the League endpoint.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
-  @v "v2.5"
+  @v "v3"
 
   @queues %{
     flex_sr: "RANKED_FLEX_SR",
     flex_tt: "RANKED_FLEX_TT",
-    solo_5: "RANKED_SOLO_5x5",
-    team_3: "RANKED_TEAM_3x3",
-    team_5: "RANKED_TEAM_5x5"
+    solo_5: "RANKED_SOLO_5x5"
   }
 
   @doc """
-  Get a list of the players from a league of the given list of summoner ids.
+  Get a list of the players from a league of the given Summoner id.
 
   ## Example
 
   ```elixir
   iex> Godfist.League.get_all(:lan, 123)
-
-  iex> Godfist.League.get_all(:lan, [123, 456, 789])
   ```
   """
   @spec get_all(atom, integer) :: {:ok, map} | {:error, String.t}
-  def get_all(region, sumid) when is_list(sumid) do
-    ids = Enum.join(sumid, ",")
-    server = Atom.to_string(region)
-
-    rest = "/api/lol/#{server}/#{@v}/league/by-summoner/#{ids}"
-
-    HTTP.get(region: region, rest: rest)
-  end
   def get_all(region, sumid) do
-    server = Atom.to_string(region)
+    rest = "/lol/league/#{@v}/leagues/by-summoner/#{sumid}"
 
-    rest = "/api/lol/#{server}/#{@v}/league/by-summoner/#{sumid}"
+    LeagueRates.handle_rate(region, rest)
+  end
 
-    HTTP.get(region: region, rest: rest)
+  @doc false
+  def get_entry(region, sumid) do
+    IO.warn("Godfist.League.get_entry/2 is deprecated, use Godfist.League.positions/2 instead",
+      Macro.Env.stacktrace(__ENV__))
+
+    positions(region, sumid)
   end
 
   @doc """
-  Get league entries mapped by Summoner Id from a given list of ids.
+  Get League positions in all queues for a given Summoner ID.
 
   ## Example
 
   ```elixir
-  iex> Godfist.League.get_entry(:lan, 123)
-
-  iex> Godfist.League.get_entry(:lan, [123, 456, 789])
+  iex> Godfist.League.positions(:lan, 24244)
   ```
   """
-  @spec get_entry(atom, list) :: {:ok, map} | {:error, String.t}
-  def get_entry(region, sumid) when is_list(sumid) do
-    ids = Enum.join(sumid, ",")
-    server = Atom.to_string(region)
+  @spec positions(atom, integer) :: {:ok, map} | {:error, String.t}
+  def positions(region, sumid) do
+    rest = "/lol/league/#{@v}/positions/by-summoner/#{sumid}"
 
-    rest = "/api/lol/#{server}/#{@v}/league/by-summoner/#{ids}/entry"
-
-    HTTP.get(region: region, rest: rest)
-  end
-  def get_entry(region, sumid) do
-    server = Atom.to_string(region)
-
-    rest = "/api/lol/#{server}/#{@v}/league/by-summoner/#{sumid}/entry"
-
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest)
   end
 
   @doc """
   Get challenger tier League mapped to queues.
 
-  Queues are: `flex_sr, flex_tt, solo_5, team_5, team_3`
+  Queues are: `flex_sr, flex_tt, solo_5`
 
   ## Example
 
@@ -84,14 +66,13 @@ defmodule Godfist.League do
   iex> Godfist.League.challenger(:oce, :team_3)
   ```
   """
-  @spec challenger(atom, Keyword.t) :: {:ok, map} | {:error, String.t}
+  @spec challenger(atom, atom) :: {:ok, map} | {:error, String.t}
   def challenger(region, rank_queue) do
     queue = Map.get(@queues, rank_queue)
-    server = Atom.to_string(region)
 
-    rest = "/api/lol/#{server}/#{@v}/league/challenger?type=#{queue}"
+    rest = "/lol/league/#{@v}/challengerleagues/by-queue/#{queue}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest)
   end
 
   @doc """
@@ -105,13 +86,12 @@ defmodule Godfist.League do
   iex> Godfist.League.master(:eune, :flex_sr)
   ```
   """
-  @spec master(atom, Keyword.t) :: {:ok, map} | {:error, String.t}
+  @spec master(atom, atom) :: {:ok, map} | {:error, String.t}
   def master(region, rank_queue) do
     queue = Map.get(@queues, rank_queue)
-    server = Atom.to_string(region)
 
-    rest = "/api/lol/#{server}/#{@v}/league/master?type=#{queue}"
+    rest = "/lol/league/#{@v}/masterleagues/by-queue/#{queue}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest)
   end
 end

--- a/lib/godfist/requests/league.ex
+++ b/lib/godfist/requests/league.ex
@@ -63,7 +63,7 @@ defmodule Godfist.League do
   ```elixir
   iex> Godfist.League.challenger(:na, :solo_5)
 
-  iex> Godfist.League.challenger(:oce, :team_3)
+  iex> Godfist.League.challenger(:oce, :flex_tt)
   ```
   """
   @spec challenger(atom, atom) :: {:ok, map} | {:error, String.t}

--- a/lib/godfist/requests/masteries.ex
+++ b/lib/godfist/requests/masteries.ex
@@ -3,7 +3,7 @@ defmodule Godfist.Masteries do
   Module to interact with the masteries endpoint.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @v "v3"
 
@@ -20,6 +20,6 @@ defmodule Godfist.Masteries do
   def get(region, sumid) do
     rest = "/lol/platform/#{@v}/masteries/by-summoner/#{sumid}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :champion_masteries_runes)
   end
 end

--- a/lib/godfist/requests/match.ex
+++ b/lib/godfist/requests/match.ex
@@ -3,7 +3,7 @@ defmodule Godfist.Match do
   Module to interact with the match endpoint.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @v "v3"
 
@@ -21,7 +21,7 @@ defmodule Godfist.Match do
     # This function gets a specific information about a match.
     rest = "/lol/match/#{@v}/matches/#{matchid}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :match)
   end
 
   @doc """
@@ -47,7 +47,8 @@ defmodule Godfist.Match do
   """
   @spec matchlist(atom, integer, Keyword.t) :: {:ok, map} | {:error, String.t}
   def matchlist(region, id, opts \\ []) do
-    # This one retrieves a list of match from a given player with optional filters.
+    # This one retrieves a list of match from a given player with optional
+    # filters.
     opt = Keyword.merge([], opts)
 
     # Yes, I know this not so appealing.
@@ -56,7 +57,7 @@ defmodule Godfist.Match do
       "queue=#{opt[:queue]}&endIndex=#{opt[:end_index]}&season=#{opt[:season]}&" <>
       "champion=#{opt[:champion]}&beginIndex=#{opt[:begin_index]}&endTime=#{opt[:end_time]}"
 
-    HTTP.get(region: region, rest: rest)
+      LeagueRates.handle_rate(region, rest, :matchlist)
   end
 
   @doc """
@@ -72,7 +73,7 @@ defmodule Godfist.Match do
   def recent(region, id) do
     rest = "/lol/match/#{@v}/matchlists/by-account/#{id}/recent"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :matchlist)
   end
 
   @doc """
@@ -88,7 +89,7 @@ defmodule Godfist.Match do
   def timeline(region, id) do
     rest = "/lol/match/#{@v}/timelines/by-match/#{id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :match)
   end
 
   @doc """
@@ -103,14 +104,15 @@ defmodule Godfist.Match do
   @spec tournament_by_code(atom, integer) :: {:ok, map} | {:error, String.t}
   def tournament_by_code(region, tournament_id) do
     # Have in mind that if you don't have permissions to fetch this api
-    # it will most likely return a 404. You can't use this one with a development
-    # key, you must register your application.
+    # it will most likely return a 404. You can't use this one with a
+    # development key, you must register your application.
     #
-    # I didn't test these two endpoints because I don't have permissions but they
+    # I didn't test these two endpoints because I don't have permissions but
+    # they
     # should work as intended, if anything, please let me know.
     rest = "/lol/match/#{@v}/matches/by-tournament-code/#{tournament_id}/ids"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 
   @doc """
@@ -126,6 +128,6 @@ defmodule Godfist.Match do
   def tournament_by_match(region, match_id, tournament_id) do
     rest = "/lol/match/#{@v}/matches/#{match_id}/by-tournament-code/#{tournament_id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 end

--- a/lib/godfist/requests/runes.ex
+++ b/lib/godfist/requests/runes.ex
@@ -3,7 +3,7 @@ defmodule Godfist.Runes do
   Module to interact with the Runes endpoint.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @v "v3"
 
@@ -20,6 +20,6 @@ defmodule Godfist.Runes do
   def summoner(region, id) do
     rest = "/lol/platform/#{@v}/runes/by-summoner/#{id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :champion_masteries_runes)
   end
 end

--- a/lib/godfist/requests/spectator.ex
+++ b/lib/godfist/requests/spectator.ex
@@ -3,7 +3,7 @@ defmodule Godfist.Spectator do
   Module to interact with the Spectator endpoint.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @endpoint "/lol/spectator/v3"
 
@@ -20,7 +20,7 @@ defmodule Godfist.Spectator do
   def active_game(region, sumid) do
     rest = @endpoint <> "/active-games/by-summoner/#{sumid}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 
   @doc """
@@ -36,6 +36,6 @@ defmodule Godfist.Spectator do
   def featured_games(region) do
     rest = @endpoint <> "/featured-games"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 end

--- a/lib/godfist/requests/static.ex
+++ b/lib/godfist/requests/static.ex
@@ -9,7 +9,7 @@ defmodule Godfist.Static do
   a single rune or mastery is a better id so... You can do it like this intead.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @endpoint "/lol/static-data/v3"
 
@@ -40,7 +40,7 @@ defmodule Godfist.Static do
     tags = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/champions?champListData=#{tags}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -53,7 +53,7 @@ defmodule Godfist.Static do
     filter = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/champions/#{id}?champData=#{filter}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -89,7 +89,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/items?itemListData=#{tag}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -102,7 +102,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/items/#{id}?tags=#{tag}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -112,7 +112,7 @@ defmodule Godfist.Static do
   def lang_strings(region) do
     rest = @endpoint <> "/language-strings"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -122,7 +122,7 @@ defmodule Godfist.Static do
   def languages(region) do
     rest = @endpoint <> "/languages"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -132,7 +132,7 @@ defmodule Godfist.Static do
   def maps(region) do
     rest = @endpoint <> "/maps"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -153,7 +153,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/masteries?tags=#{tag}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -166,7 +166,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/masteries/#{id}?masteryData=#{tag}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -176,7 +176,7 @@ defmodule Godfist.Static do
   def profile_icons(region) do
     rest = @endpoint <> "/profile-icons"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -186,7 +186,7 @@ defmodule Godfist.Static do
   def realms(region) do
     rest = @endpoint <> "/realms"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -205,7 +205,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/runes?runeListData=#{tag}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -218,7 +218,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/runes/#{id}?tags=#{tag}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -252,7 +252,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/summoner-spells?spellListData=#{tag}&dataById=true"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -265,7 +265,7 @@ defmodule Godfist.Static do
     tag = Keyword.get(opts, :filter, "all")
     rest = @endpoint <> "/summoner-spells/#{id}?spellData=#{tag}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 
   @doc """
@@ -275,6 +275,6 @@ defmodule Godfist.Static do
   def versions(region) do
     rest = @endpoint <> "/versions"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :static)
   end
 end

--- a/lib/godfist/requests/status.ex
+++ b/lib/godfist/requests/status.ex
@@ -3,7 +3,7 @@ defmodule Godfist.Status do
   Status endpoint.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @v "v3"
 
@@ -16,6 +16,6 @@ defmodule Godfist.Status do
   def shard(region) do
     rest = "/lol/status/#{@v}/shard-data"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 end

--- a/lib/godfist/requests/summoner.ex
+++ b/lib/godfist/requests/summoner.ex
@@ -3,7 +3,7 @@ defmodule Godfist.Summoner do
   Module to interact with the Summoner endpoint.
   """
 
-  alias Godfist.HTTP
+  alias Godfist.LeagueRates
 
   @endpoint "/lol/summoner/v3/summoners"
 
@@ -20,7 +20,7 @@ defmodule Godfist.Summoner do
   def by_id(region, id) do
     rest = @endpoint <> "/by-account/#{id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 
   @doc """
@@ -36,7 +36,7 @@ defmodule Godfist.Summoner do
   def by_name(region, name) do
     rest = @endpoint <> "/by-name/#{name}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 
   @doc """
@@ -56,7 +56,7 @@ defmodule Godfist.Summoner do
     # Just that it uses summoner id instead of account id
     rest = @endpoint <> "/#{id}"
 
-    HTTP.get(region: region, rest: rest)
+    LeagueRates.handle_rate(region, rest, :other)
   end
 
   @doc """
@@ -74,7 +74,7 @@ defmodule Godfist.Summoner do
     rest = @endpoint <> "/by-name/#{name}"
 
     # I can probably do this in a more elegant way?
-    case HTTP.get(region: region, rest: rest) do
+    case LeagueRates.handle_rate(region, rest, :other) do
       {:ok, "Not found"} ->
         {:error, "Summoner not found"}
       {:ok, summ} ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,17 +1,21 @@
 defmodule Godfist.Mixfile do
+  @moduledoc false
+
   use Mix.Project
 
   def project do
-    [app: :godfist,
-     version: "0.2.2",
-     elixir: "~> 1.4",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     test_coverage: [tool: ExCoveralls],
+    [
+      app: :godfist,
+      version: "0.2.2",
+      elixir: "~> 1.4",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      test_coverage: [tool: ExCoveralls],
       preferred_cli_env: ["coveralls": :test, "coveralls.html": :test],
-     description: description(),
-     package: pkg(),
-     deps: deps()]
+      description: description(),
+      package: pkg(),
+      deps: deps()
+    ]
   end
 
   defp description do
@@ -41,6 +45,7 @@ defmodule Godfist.Mixfile do
       {:poison, "~> 3.1"},
       {:ex_rated, "~> 1.3"},
       {:cachex, "~> 2.1"},
+
       {:credo, "~> 0.7.4", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:excoveralls, "~> 0.6", only: :test}

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Godfist.Mixfile do
   def project do
     [
       app: :godfist,
-      version: "0.2.2",
+      version: "0.3.0",
       elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/godfist_main.exs
+++ b/test/godfist_main.exs
@@ -1,13 +1,14 @@
 defmodule Godfist.Main do
+  @moduledoc false
+
   use ExUnit.Case
 
   test "return account id and summoner id of player" do
     {:ok, account_id} = Godfist.get_account_id(:lan, "Mjólner")
-    assert 200008206 == account_id
-
+    assert 200_008_206 == account_id
 
     {:ok, summoner_id} = Godfist.get_summid(:lan, "Mjólner")
-    assert 24244 == summoner_id
+    assert 24_244 == summoner_id
   end
 
   test "return matchlist" do

--- a/test/godfist_test.exs
+++ b/test/godfist_test.exs
@@ -1,14 +1,15 @@
 defmodule GodfistTest do
+  @moduledoc false
+
   use ExUnit.Case
 
   alias Godfist.{ChampionMastery, Champion, League, Status, Masteries,
         Match, Runes, Spectator, Static, Summoner}
 
-  @sumid 24244
-  @sumids [200203, 24244]
-  @lasid 204359681
-  @lasmatchid 460035794
-  @naid 39626602
+  @sumid 24_244
+  @lasid 204_359_681
+  @lasmatchid 460_035_794
+  @naid 39_626_602
   @champid 64
 
   # Champion mastery tests.
@@ -40,18 +41,14 @@ defmodule GodfistTest do
   # League tests
   test "return league information about given players" do
     single = League.get_all(:lan, @sumid)
-    multiple = League.get_all(:lan, @sumids)
 
     assert {:ok, _} = single
-    assert {:ok, _} = multiple
   end
 
   test "return information about players" do
     single = League.get_entry(:lan, @sumid)
-    multiple = League.get_entry(:lan, @sumids)
 
     assert {:ok, _} = single
-    assert {:ok, _} = multiple
   end
 
   test "return challenger league" do
@@ -180,7 +177,7 @@ defmodule GodfistTest do
   end
 
   test "return summoner by sumoner id" do
-    assert {:ok, _} = Summoner.by_summid(:las, 12200604) # Summoner id
+    assert {:ok, _} = Summoner.by_summid(:las, 12_200_604) # Summoner id
   end
 
   test "return id of summoner by name" do


### PR DESCRIPTION
#5 
I implemented a GenServer to help keep track of the rate limits per method and added another _checker_ to short and long term developer limits.

@hankditton The rate limits shown [here](https://developer.riotgames.com/rate-limiting.html) are the ones used in production too, right? If that's it then I'm looking to merge.

After this I'll probably bump the version and update on hex.